### PR TITLE
RecipeOverview successfully displays seed data but requires further styling focus

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -23,7 +23,8 @@ import Login from './src/views/Login';
 import Dashboard from './src/views/Dashboard.js';
 import MyRecipes from './src/views/MyRecipes.js';
 import RecipeForm from './src/views/RecipeForm.js';
-import Recipe from './src/views/Recipe.js';
+// import Recipe from './src/views/Recipe.js';
+import RecipeOverview from './src/views/RecipeOverview';
 import UserRecipe from './src/views/UserRecipe.js';
 import * as firebase from 'firebase';
 
@@ -125,7 +126,8 @@ const AppNavigator = createStackNavigator(
       screen: RecipeForm
     },
     Recipe: {
-      screen: Recipe
+      // screen: Recipe
+      screen: RecipeOverview
     },
     UserRecipe: {
       screen: UserRecipe

--- a/frontend/src/styling/RecipeOverviewStyling.js
+++ b/frontend/src/styling/RecipeOverviewStyling.js
@@ -5,7 +5,8 @@ export default StyleSheet.create({
     width: '100%',
     height: '100%',
     padding: 20,
-    backgroundColor: '#F6F7F7'
+    backgroundColor: '#F6F7F7',
+    color: '#231C1C'
   },
   titleBox: {
     width: '100%',
@@ -21,5 +22,23 @@ export default StyleSheet.create({
     padding: 20,
     backgroundColor: '#E8ECEC',
     borderRadius: 2,
+  },
+  innerBox: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  titleTitle: {
+    fontSize: 26,
+    fontWeight: '700',
+  },
+  titleCat: {
+    fontSize: 14,
+    fontWeight: '300'
+  },
+  titleContent: {
+    fontSize: 16,
+    fontWeight: '500'
   }
 });

--- a/frontend/src/styling/RecipeOverviewStyling.js
+++ b/frontend/src/styling/RecipeOverviewStyling.js
@@ -1,5 +1,17 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  
+  viewBox: {
+    width: '100%',
+    height: '100%',
+    padding: 20,
+    backgroundColor: '#F6F7F7'
+  },
+  contentBox: {
+    width: '100%',
+    height: 'auto',
+    padding: 20,
+    backgroundColor: '#E8ECEC',
+    borderRadius: 2,
+  }
 });

--- a/frontend/src/styling/RecipeOverviewStyling.js
+++ b/frontend/src/styling/RecipeOverviewStyling.js
@@ -29,16 +29,44 @@ export default StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between'
   },
-  titleTitle: {
-    fontSize: 26,
+  catBox: {
+    width: 100
+  },
+  yieldBox: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  catCoarse: {
+    width: 150
+  },
+  titleText: {
+    fontSize: 24,
     fontWeight: '700',
   },
-  titleCat: {
+  lightText: {
     fontSize: 14,
     fontWeight: '300'
   },
-  titleContent: {
+  regularText: {
+    fontSize: 15,
+    fontWeight: '400'
+  },
+  mediumText: {
     fontSize: 16,
     fontWeight: '500'
+  },
+  boldText: {
+    fontSize: 18,
+    fontWeight: '700'
+  },
+  yieldRegularText: {
+    fontSize: 15,
+    fontWeight: '400'
+  },
+  yieldBoldText: {
+    width: 50,
+    marginRight: 20,
+    fontSize: 18,
+    fontWeight: '700'
   }
 });

--- a/frontend/src/styling/RecipeOverviewStyling.js
+++ b/frontend/src/styling/RecipeOverviewStyling.js
@@ -7,9 +7,17 @@ export default StyleSheet.create({
     padding: 20,
     backgroundColor: '#F6F7F7'
   },
+  titleBox: {
+    width: '100%',
+    height: 'auto',
+    padding: 20,
+    backgroundColor: '#E8ECEC',
+    borderRadius: 2,
+  },
   contentBox: {
     width: '100%',
     height: 'auto',
+    marginTop: 14,
     padding: 20,
     backgroundColor: '#E8ECEC',
     borderRadius: 2,

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -38,17 +38,25 @@ const RecipeOverview = props => {
     <View>
       <NavBar {...props}/>
       <View style={styles.viewBox}>
-        <View style={styles.contentBox}>
+        <View style={styles.titleBox}>
           <Text>{currentRecipe.title}</Text>
           <Text>{currentRecipe.brew_type}</Text>
           <Text>{currentRecipe.water_temp}</Text>
         </View>
         <ScrollView>
-          {sortedInstructions.map((instruction, index) => {
-            <View key={index} style={styles.contentBox}>
-              <Text>{instruction}</Text>
+          {sortedInstructions.map((instruction, index) => (
+            <View>
+              <View key={index} style={styles.contentBox}>
+                <Text key={index}>{instruction}</Text>
+              </View>
+              <View key={index} style={styles.contentBox}>
+                <Text key={index}>{instruction}</Text>
+              </View>
+              <View key={index} style={styles.contentBox}>
+                <Text key={index}>{instruction}</Text>
+              </View>
             </View>
-          })}
+          ))}
         </ScrollView>
       </View>
     </View>

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -39,9 +39,18 @@ const RecipeOverview = props => {
       <NavBar {...props}/>
       <View style={styles.viewBox}>
         <View style={styles.titleBox}>
-          <Text>{currentRecipe.title}</Text>
-          <Text>{currentRecipe.brew_type}</Text>
-          <Text>{currentRecipe.water_temp}</Text>
+          <Text style={styles.titleTitle}>{currentRecipe.title}</Text>
+          <View style={styles.innerBox}>
+            <Text style={styles.titleCat}>Creator</Text>
+            <Text style={styles.titleCat}>Brew Temp</Text>
+            <Text style={styles.titleCat}>Coarseness</Text>
+          </View>
+          <View style={styles.innerBox}>
+            <Text style={styles.titleContent}>Brew Plans</Text>
+            <Text style={styles.titleContent}>{currentRecipe.water_temp}</Text>
+            <Text style={styles.titleContent}>Medium</Text>
+          </View>
+          
         </View>
         <ScrollView>
           <View>

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -38,12 +38,12 @@ const RecipeOverview = props => {
     <View>
       <NavBar {...props}/>
       <View style={styles.viewBox}>
+        <View style={styles.titleBox}>
+          <Text>{currentRecipe.title}</Text>
+          <Text>{currentRecipe.brew_type}</Text>
+          <Text>{currentRecipe.water_temp}</Text>
+        </View>
         <ScrollView>
-          <View style={styles.titleBox}>
-            <Text>{currentRecipe.title}</Text>
-            <Text>{currentRecipe.brew_type}</Text>
-            <Text>{currentRecipe.water_temp}</Text>
-          </View>
           <View>
             <View style={styles.contentBox}>
               <Text>You'll Need...</Text>

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -1,19 +1,56 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import { View, ScrollView, Text, Image } from 'react-native';
+import { View, ScrollView, Text } from 'react-native';
 
 import NavBar from '../components/Layout/NavBar/NavBar';
 import styles from '../styling/RecipeOverviewStyling';
 
 const RecipeOverview = props => {
+  const [ sortedInstructions, setSortedInstructions ] = useState([]);
   const { currentRecipe } = props;
+  const instructions = currentRecipe;
+
+  const regex = new RegExp(/^\d+/g);
+
+  useEffect(() => {
+    if(instructions) {
+      let instructionsToSplit = instructions + " ";
+      const instructionsArray = instructionsToSplit.split("////");
+      let localInstructions = [];
+
+      instructionsArray.map((instruction, index) => {
+        let step = `Step ${index + 1}`;
+        const result = instruction.match(regex);
+
+        if(result) {
+          instruction = instruction.substr(instruction.indexOf(' ') + 1);
+        };
+
+        let res = step.concat(instruction);
+        localInstructions.push(res);
+      });
+
+      setSortedInstructions([...localInstructions]);
+    };
+  }, []);
 
   return (
     <View>
-      <NavBar />
-      <ScrollView>
-        <Text>{currentRecipe.title}</Text>
-      </ScrollView>
+      <NavBar {...props}/>
+      <View style={styles.viewBox}>
+        <View style={styles.contentBox}>
+          <Text>{currentRecipe.title}</Text>
+          <Text>{currentRecipe.brew_type}</Text>
+          <Text>{currentRecipe.water_temp}</Text>
+        </View>
+        <ScrollView>
+          {sortedInstructions.map((instruction, index) => {
+            <View key={index} style={styles.contentBox}>
+              <Text>{instruction}</Text>
+            </View>
+          })}
+        </ScrollView>
+      </View>
     </View>
   );
 };

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -8,22 +8,22 @@ import styles from '../styling/RecipeOverviewStyling';
 const RecipeOverview = props => {
   const [ sortedInstructions, setSortedInstructions ] = useState([]);
   const { currentRecipe } = props;
-  const instructions = currentRecipe;
+  const { instructions } = currentRecipe;
 
   const regex = new RegExp(/^\d+/g);
 
   useEffect(() => {
     if(instructions) {
-      let instructionsToSplit = instructions + " ";
-      const instructionsArray = instructionsToSplit.split("////");
+      const instructionsArray = instructions.split("////");
       let localInstructions = [];
 
       instructionsArray.map((instruction, index) => {
-        let step = `Step ${index + 1}`;
+        let step = `Step ${index + 1}
+`;
         const result = instruction.match(regex);
 
         if(result) {
-          instruction = instruction.substr(instruction.indexOf(' ') + 1);
+          instruction = instruction.substr(instruction.indexOf(" ") + 1);
         };
 
         let res = step.concat(instruction);
@@ -38,25 +38,34 @@ const RecipeOverview = props => {
     <View>
       <NavBar {...props}/>
       <View style={styles.viewBox}>
-        <View style={styles.titleBox}>
-          <Text>{currentRecipe.title}</Text>
-          <Text>{currentRecipe.brew_type}</Text>
-          <Text>{currentRecipe.water_temp}</Text>
-        </View>
         <ScrollView>
-          {sortedInstructions.map((instruction, index) => (
-            <View>
-              <View key={index} style={styles.contentBox}>
-                <Text key={index}>{instruction}</Text>
-              </View>
-              <View key={index} style={styles.contentBox}>
-                <Text key={index}>{instruction}</Text>
-              </View>
-              <View key={index} style={styles.contentBox}>
-                <Text key={index}>{instruction}</Text>
-              </View>
+          <View style={styles.titleBox}>
+            <Text>{currentRecipe.title}</Text>
+            <Text>{currentRecipe.brew_type}</Text>
+            <Text>{currentRecipe.water_temp}</Text>
+          </View>
+          <View>
+            <View style={styles.contentBox}>
+              <Text>You'll Need...</Text>
+              <Text>
+                Tool 1
+                Tool 2
+                Grounds 1
+                Water
+                Etc.
+              </Text>
             </View>
-          ))}
+            <View style={styles.contentBox}>
+              {sortedInstructions.map((instruction, index) => (
+                // <Text key={index}>{this.step}</Text>
+                <Text key={index}>{instruction}</Text>
+              ))}
+            </View>
+            <View style={styles.contentBox}>
+              <Text>Yield: 2 cups</Text>
+              <Text>Time: 4 minutes</Text>
+            </View>
+          </View>
         </ScrollView>
       </View>
     </View>

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -39,24 +39,27 @@ const RecipeOverview = props => {
       <NavBar {...props}/>
       <View style={styles.viewBox}>
         <View style={styles.titleBox}>
-          <Text style={styles.titleTitle}>{currentRecipe.title}</Text>
+          <Text style={styles.titleText}>{currentRecipe.title}</Text>
           <View style={styles.innerBox}>
-            <Text style={styles.titleCat}>Creator</Text>
-            <Text style={styles.titleCat}>Brew Temp</Text>
-            <Text style={styles.titleCat}>Coarseness</Text>
+            <View style={styles.catBox}>
+              <Text style={styles.lightText}>Creator</Text>
+              <Text style={styles.mediumText}>Brew Plans</Text>
+            </View>
+            <View style={styles.catBox}>
+              <Text style={styles.lightText}>Brew Temp</Text>
+              <Text style={styles.mediumText}>{currentRecipe.water_temp}º F</Text>
+            </View>
+            <View style={styles.catCoarse}>
+              <Text style={styles.lightText}>Coarseness</Text>
+              <Text style={styles.mediumText}>Medium-Coarse</Text>
+            </View>
           </View>
-          <View style={styles.innerBox}>
-            <Text style={styles.titleContent}>Brew Plans</Text>
-            <Text style={styles.titleContent}>{currentRecipe.water_temp}</Text>
-            <Text style={styles.titleContent}>Medium</Text>
-          </View>
-          
         </View>
         <ScrollView>
           <View>
             <View style={styles.contentBox}>
-              <Text>You'll Need...</Text>
-              <Text>
+              <Text style={styles.titleText}>You'll Need...</Text>
+              <Text style={styles.lightText}>
                 Tool 1
                 Tool 2
                 Grounds 1
@@ -67,12 +70,18 @@ const RecipeOverview = props => {
             <View style={styles.contentBox}>
               {sortedInstructions.map((instruction, index) => (
                 // <Text key={index}>{this.step}</Text>
-                <Text key={index}>{instruction}</Text>
+                <Text style={styles.regularText} key={index}>{instruction}</Text>
               ))}
             </View>
             <View style={styles.contentBox}>
-              <Text>Yield: 2 cups</Text>
-              <Text>Time: 4 minutes</Text>
+              <View style={styles.yieldBox}>
+                <Text style={styles.yieldBoldText}>Yield</Text>
+                <Text style={styles.yieldRegularText}>2 cups</Text>
+              </View>
+              <View style={styles.yieldBox}>
+                <Text style={styles.yieldBoldText}>Time</Text>
+                <Text style={styles.yieldRegularText}>4 minutes</Text>
+              </View>
             </View>
           </View>
         </ScrollView>


### PR DESCRIPTION
# Description

Using the `Recipe`'s place in `Apps.js`, I was able to build a `RecipeOverview.js` that successfully retrieves the steps and temperature attached to the seeded recipes. I chose to comment out `Recipe` for simple discovery through the provided buttons. 

## Features

- [x] Calls seeded recipe data without issue
- [ ] Callpoints made in preparation for all data to be created for the future
- [x] Stylesheet built
- [ ] Stylesheet application completed
- [ ] Stylesheet functions without issue

## Issues to report

- Scrollview is restricted somehow; doesn't allow for full scrolling without holding screen up
- Step title unchangeable with current display method; looking to find means of displaying desired aesthetic

## Change status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [x] Incomplete/work-in-progress, PR is for discussion/feedback
