### PR TITLE
Steps and ScrollView issues fixed; Overview accessible from buttons on App

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -23,7 +23,7 @@ import Login from './src/views/Login';
 import Dashboard from './src/views/Dashboard.js';
 import MyRecipes from './src/views/MyRecipes.js';
 import RecipeForm from './src/views/RecipeForm.js';
-// import Recipe from './src/views/Recipe.js';
+import Recipe from './src/views/Recipe.js';
 import RecipeOverview from './src/views/RecipeOverview';
 import UserRecipe from './src/views/UserRecipe.js';
 import StartBrew from './src/views/StartBrew';
@@ -128,7 +128,7 @@ const AppNavigator = createStackNavigator(
       screen: StartBrew
     },
     Overview: {
-      screen: Overview
+      screen: RecipeOverview
     },
 
     RecipeSteps: {
@@ -139,8 +139,7 @@ const AppNavigator = createStackNavigator(
       screen: RecipeForm
     },
     Recipe: {
-      // screen: Recipe
-      screen: RecipeOverview
+      screen: Recipe
     },
     UserRecipe: {
       screen: UserRecipe

--- a/frontend/src/styling/RecipeOverviewStyling.js
+++ b/frontend/src/styling/RecipeOverviewStyling.js
@@ -3,21 +3,20 @@ import { StyleSheet } from 'react-native';
 export default StyleSheet.create({
   viewBox: {
     width: '100%',
-    height: '100%',
     padding: 20,
+    display: 'flex',
+    alignContent: 'center',
     backgroundColor: '#F6F7F7',
     color: '#231C1C'
   },
   titleBox: {
     width: '100%',
-    height: 'auto',
     padding: 20,
     backgroundColor: '#E8ECEC',
     borderRadius: 2,
   },
   contentBox: {
     width: '100%',
-    height: 'auto',
     marginTop: 14,
     padding: 20,
     backgroundColor: '#E8ECEC',
@@ -48,6 +47,7 @@ export default StyleSheet.create({
     fontWeight: '300'
   },
   regularText: {
+    marginTop: 2,
     fontSize: 15,
     fontWeight: '400'
   },
@@ -56,6 +56,7 @@ export default StyleSheet.create({
     fontWeight: '500'
   },
   boldText: {
+    marginTop: 4,
     fontSize: 18,
     fontWeight: '700'
   },

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -17,15 +17,13 @@ const RecipeOverview = props => {
       const instructionsArray = instructions.split("////");
       let localInstructions = [];
 
-      instructionsArray.map((instruction, index) => {
-        var step = `Step ${index + 1}`;
+      instructionsArray.map((instruction) => {
         const result = instruction.match(regex);
 
         if(result) {
           instruction = instruction.substr(instruction.indexOf(" ") + 1);
         };
 
-        // let res = step.concat(instruction);
         localInstructions.push(instruction);
       });
 

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -18,16 +18,15 @@ const RecipeOverview = props => {
       let localInstructions = [];
 
       instructionsArray.map((instruction, index) => {
-        let step = `Step ${index + 1}
-`;
+        var step = `Step ${index + 1}`;
         const result = instruction.match(regex);
 
         if(result) {
           instruction = instruction.substr(instruction.indexOf(" ") + 1);
         };
 
-        let res = step.concat(instruction);
-        localInstructions.push(res);
+        // let res = step.concat(instruction);
+        localInstructions.push(instruction);
       });
 
       setSortedInstructions([...localInstructions]);
@@ -35,27 +34,27 @@ const RecipeOverview = props => {
   }, []);
 
   return (
-    <View>
+    <View style={{ flex: 1 }}>
       <NavBar {...props}/>
-      <View style={styles.viewBox}>
-        <View style={styles.titleBox}>
-          <Text style={styles.titleText}>{currentRecipe.title}</Text>
-          <View style={styles.innerBox}>
-            <View style={styles.catBox}>
-              <Text style={styles.lightText}>Creator</Text>
-              <Text style={styles.mediumText}>Brew Plans</Text>
-            </View>
-            <View style={styles.catBox}>
-              <Text style={styles.lightText}>Brew Temp</Text>
-              <Text style={styles.mediumText}>{currentRecipe.water_temp}º F</Text>
-            </View>
-            <View style={styles.catCoarse}>
-              <Text style={styles.lightText}>Coarseness</Text>
-              <Text style={styles.mediumText}>Medium-Coarse</Text>
+      <ScrollView style={{ flex: 1 }}>
+        <View style={styles.viewBox}>
+          <View style={styles.titleBox}>
+            <Text style={styles.titleText}>{currentRecipe.title}</Text>
+            <View style={styles.innerBox}>
+              <View style={styles.catBox}>
+                <Text style={styles.lightText}>Creator</Text>
+                <Text style={styles.mediumText}>Brew Plans</Text>
+              </View>
+              <View style={styles.catBox}>
+                <Text style={styles.lightText}>Brew Temp</Text>
+                <Text style={styles.mediumText}>{currentRecipe.water_temp}º F</Text>
+              </View>
+              <View style={styles.catCoarse}>
+                <Text style={styles.lightText}>Coarseness</Text>
+                <Text style={styles.mediumText}>Medium-Coarse</Text>
+              </View>
             </View>
           </View>
-        </View>
-        <ScrollView>
           <View>
             <View style={styles.contentBox}>
               <Text style={styles.titleText}>You'll Need...</Text>
@@ -69,8 +68,10 @@ const RecipeOverview = props => {
             </View>
             <View style={styles.contentBox}>
               {sortedInstructions.map((instruction, index) => (
-                // <Text key={index}>{this.step}</Text>
-                <Text style={styles.regularText} key={index}>{instruction}</Text>
+                <View key={index}>
+                  <Text style={styles.boldText}>Step {index + 1}</Text>
+                  <Text style={styles.regularText}>{instruction}</Text>
+                </View>
               ))}
             </View>
             <View style={styles.contentBox}>
@@ -84,8 +85,8 @@ const RecipeOverview = props => {
               </View>
             </View>
           </View>
-        </ScrollView>
-      </View>
+        </View>
+      </ScrollView>
     </View>
   );
 };

--- a/frontend/src/views/StartBrew.js
+++ b/frontend/src/views/StartBrew.js
@@ -36,10 +36,12 @@ function StartBrew(props) {
                 />
                 </TouchableOpacity>
             </View>
-            <View style={ styles.overview }>
-                <Text style={ styles.overviewText }>Overview</Text>
-                <Text style={ styles.overviewText }>+</Text>
-            </View>
+            <TouchableOpacity onPress={() => props.navigation.navigate('Overview')}>
+                <View style={ styles.overview }>
+                    <Text style={ styles.overviewText }>Overview</Text>
+                    <Text style={ styles.overviewText }>+</Text>
+                </View>
+            </TouchableOpacity>
         </View>
     )
 }
@@ -53,7 +55,6 @@ const styles = StyleSheet.create({
     overview: {
         backgroundColor: '#1f2233', 
         width: '100%', 
-        position: 'absolute', 
         bottom: 0, 
         justifyContent: 'space-between', 
         flexDirection: 'row', 


### PR DESCRIPTION
# Description

Replaced `Overview`'s place in `Apps.js` with `RecipeOverview` so that the new component can be viewed via `StartBrew` as well as `RecipeSteps`. ScrollView issue was resolved, as was the styling restriction in reference to steps numbering generation.

Fixes 3

- Scrollview is no longer restricted and is capable of resting at the bottom of the screen
- Step title is now styled
- @tlaudahl helped clear a key index error from system

## Features

- [x] Calls seeded recipe data without issue
- [ ] Callpoints made in preparation for all data to be created for the future
- [ ] Has header box with button to return to previous page
- [x] Accessible from `RecipeSteps` and `StartBrew`
- [x] Stylesheet built
- [x] Stylesheet application completed
- [x] Stylesheet functions without issue

## Issues to report

- `Overview` button does not reach the bottom of `StartBrew` page

## Change status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [x] Incomplete/work-in-progress, PR is for discussion/feedback
