### PR TITLE
Overview now allows users to close page easily

### DIFF
--- a/frontend/src/components/Layout/OverviewBar.js
+++ b/frontend/src/components/Layout/OverviewBar.js
@@ -14,7 +14,7 @@ const OverviewBar = props => {
           <Appbar.Action
             icon="close"
             color="white"
-            // onPress={props.navigation.goBack()}
+            onPress={() => props.navigation.goBack()}
           />
         </View>
       </Appbar>

--- a/frontend/src/components/Layout/OverviewBar.js
+++ b/frontend/src/components/Layout/OverviewBar.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { Appbar } from 'react-native-paper';
+
+import styles from '../../styling/OverviewBarStyling';
+import theme from '../../theme';
+
+const OverviewBar = props => {
+  return (
+    <View>
+      <Appbar style={styles.Appbox} theme={theme}>
+        <View style={styles.viewBox}>
+          <Text style={styles.overText}>Overview</Text>
+          <Appbar.Action
+            icon="close"
+            color="white"
+            // onPress={props.navigation.goBack()}
+          />
+        </View>
+      </Appbar>
+    </View>
+  )
+};
+
+export default OverviewBar;

--- a/frontend/src/styling/OverviewBarStyling.js
+++ b/frontend/src/styling/OverviewBarStyling.js
@@ -1,0 +1,22 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  Appbox: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'row'
+  },
+  viewBox: {
+    flexDirection: 'row',
+    width: '100%',
+    height: '100%',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 6,
+    zIndex: 151,
+  },
+  overText: {
+    fontSize: 26,
+    color: '#FFFFFF'
+  }
+})

--- a/frontend/src/styling/OverviewBarStyling.js
+++ b/frontend/src/styling/OverviewBarStyling.js
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 export default StyleSheet.create({
   Appbox: {
     width: '100%',
+    marginTop: 24,
     display: 'flex',
     flexDirection: 'row'
   },

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { View, ScrollView, Text } from 'react-native';
 
-import NavBar from '../components/Layout/NavBar/NavBar';
+import OverviewBar from '../components/Layout/OverviewBar';
 import styles from '../styling/RecipeOverviewStyling';
 
 const RecipeOverview = props => {
@@ -33,7 +33,7 @@ const RecipeOverview = props => {
 
   return (
     <View style={{ flex: 1 }}>
-      <NavBar {...props}/>
+      <OverviewBar {...props} />
       <ScrollView style={{ flex: 1 }}>
         <View style={styles.viewBox}>
           <View style={styles.titleBox}>

--- a/frontend/src/views/RecipeOverview.js
+++ b/frontend/src/views/RecipeOverview.js
@@ -56,13 +56,11 @@ const RecipeOverview = props => {
           <View>
             <View style={styles.contentBox}>
               <Text style={styles.titleText}>You'll Need...</Text>
-              <Text style={styles.lightText}>
-                Tool 1
-                Tool 2
-                Grounds 1
-                Water
-                Etc.
-              </Text>
+              <Text style={styles.lightText}>Tool 1</Text>
+              <Text style={styles.lightText}>Tool 2</Text>
+              <Text style={styles.lightText}>Grounds</Text>
+              <Text style={styles.lightText}>Water</Text>
+              <Text style={styles.lightText}>Etc.</Text>
             </View>
             <View style={styles.contentBox}>
               {sortedInstructions.map((instruction, index) => (

--- a/frontend/src/views/StartBrew.js
+++ b/frontend/src/views/StartBrew.js
@@ -22,7 +22,7 @@ function StartBrew(props) {
                 <Text style={ styles.recipeInfoText }>Brew Type: {currentRecipe.brew_type}</Text>
                 <Text style={ styles.recipeInfoText }>Water Temp: {currentRecipe.water_temp}&deg;F</Text>
             </View>
-            <View style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <View style={{ justifyContent: 'space-between', alignItems: 'center', flex: 1 }}>
                 <Image
                 source={require('../../assets/coffee-bean.png')}
                 style={{ marginVertical: 10 }}
@@ -58,7 +58,7 @@ const styles = StyleSheet.create({
         bottom: 0, 
         justifyContent: 'space-between', 
         flexDirection: 'row', 
-        padding: '2%'
+        padding: '2%',
     },
     recipeInfoText: {
         color: 'white',
@@ -77,7 +77,8 @@ const styles = StyleSheet.create({
     },
     mainView: {
         width: '100%',
-        height: '100%'
+        height: '100%',
+        flex: 1,
     }
 })
 


### PR DESCRIPTION
# Description

Created `OverviewBar` component and styling sheet to allow users an easier exiting feature from `RecipeOverview`. Styling applied follows styling guidelines as functions as expected.

Fixes 3

- `Overview` button snapped to the bottom
- Exiting `OverviewBar` component no longer auto-closes because of function issue 

## Features

- [x] Calls seeded recipe data without issue
- [ ] Callpoints made in preparation for all data to be created for the future
- [x] Has header box with button to return to previous page
- [x] Accessible from `RecipeSteps` and `StartBrew`
- [x] Stylesheet built
- [x] Stylesheet application completed
- [x] Stylesheet functions without issue

## Issues to report

- None

## Change status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [x] Incomplete/work-in-progress, PR is for discussion/feedback
